### PR TITLE
Add osx-arm64 build

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+ncurses:
+- '6'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -46,6 +46,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -77,6 +77,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
 
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -41,6 +41,11 @@ if EXIST LICENSE.txt (
     echo Copying feedstock license
     copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
 )
+if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+    if [%CROSSCOMPILING_EMULATOR%] == [] (
+        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    )
+)
 
 if NOT [%flow_run_id%] == [] (
     set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --extra-meta flow_run_id=%flow_run_id% remote_url=%remote_url% sha=%sha%"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6046&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ldc-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6046&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,7 @@
 bot:
   automerge: true
+build_platform:
+  osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true
@@ -8,3 +10,4 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: default
+test: native_and_emulated

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ if [[ "${build_platform}" == "osx-arm64" ]]; then
 fi
 
 # In the future we can just use mamba install to get a previous version on all platforms
-if [[ $BOOTSTRAP ]]; then
+if [[ $BOOTSTRAP == "true" ]]; then
     LDC_VERSION=1.38.0 # Try using newest version first
     curl -fsS https://dlang.org/install.sh | bash -s ldc-$LDC_VERSION
     source ~/dlang/ldc-$LDC_VERSION/activate
@@ -34,7 +34,7 @@ ldc2 -version
 
 cd ..
 rm -rf build
-if [[ $BOOTSTRAP ]]; then
+if [[ $BOOTSTRAP == "true" ]]; then
     deactivate
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,9 +2,14 @@
 set -eu -o pipefail
 set -x
 
+BOOTSTRAP=false
+if [[ "${build_platform}" == "osx-arm64" ]]; then
+    BOOTSTRAP=true
+fi
+
 # In the future we can just use mamba install to get a previous version on all platforms
-if [[ "${build_platform}" == "linux-aarch64" ]]; then
-    LDC_VERSION=1.26.0 # Latest version that works with glibc 2.17
+if [[ $BOOTSTRAP ]]; then
+    LDC_VERSION=1.38.0 # Try using newest version first
     curl -fsS https://dlang.org/install.sh | bash -s ldc-$LDC_VERSION
     source ~/dlang/ldc-$LDC_VERSION/activate
     ldc2 -version
@@ -29,7 +34,7 @@ ldc2 -version
 
 cd ..
 rm -rf build
-if [[ "${build_platform}" == "linux-aarch64" ]]; then
+if [[ $BOOTSTRAP ]]; then
     deactivate
 fi
 


### PR DESCRIPTION
- **migration: OSXArm**
- **MNT: Re-rendered with conda-build 24.5.1, conda-smithy 3.36.2, and conda-forge-pinning 2024.07.02.10.47.51**
- **Use bootstrap compiler for osx-arm64**

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
